### PR TITLE
Print locale information

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 int main() 
 {
    std::setlocale(LC_ALL, ".UTF-8");
+   std::cout << "setlocale info: " << setlocale(LC_ALL, NULL) << std::endl;
 
    std::cout << "Before regex" << std::endl;
 


### PR DESCRIPTION
This will help troubleshoot runtime differences.

On my system, MINGW64 fails to set a utf-8 codepage, and leaves it as `C`, but UCRT64 sets it to `English_Ireland.utf8`.

